### PR TITLE
Action Supervisor Bug Fix

### DIFF
--- a/pkg/action/supervisor/action_supervisor.go
+++ b/pkg/action/supervisor/action_supervisor.go
@@ -133,12 +133,12 @@ func (s *ActionSupervisor) checkScaleAction(action *turboaction.TurboAction) (bo
 		glog.V(4).Infof("currentReplicas from RC is %d", currentReplicas)
 		break
 	case turboaction.TypeReplicaSet:
-		targetDeployment, err := s.config.kubeClient.Deployments(namespace).Get(name)
-		if err != nil || targetDeployment == nil {
-			return false, fmt.Errorf("Cannot find deployment for %s in cluster", identifier)
+		targetReplicaSet, err := s.config.kubeClient.ReplicaSets(namespace).Get(name)
+		if err != nil || targetReplicaSet == nil {
+			return false, fmt.Errorf("Cannot find replica set for %s in cluster", identifier)
 		}
-		currentReplicas = targetDeployment.Spec.Replicas
-		glog.V(4).Infof("currentReplicas from Deployment is %d", currentReplicas)
+		currentReplicas = targetReplicaSet.Spec.Replicas
+		glog.V(4).Infof("current replica of target replica set is %d", currentReplicas)
 		break
 	}
 

--- a/pkg/api/vmtapi.go
+++ b/pkg/api/vmtapi.go
@@ -109,6 +109,10 @@ func (vmtApi *VmtApi) apiPost(postUrl, requestDataString string) (string, error)
 		glog.Errorf("Error getting response: %s", err)
 		return "", err
 	}
+	if resp.StatusCode != 200 {
+		glog.Errorf("Response failed: %s", resp.Status)
+		return "", err
+	}
 	glog.V(4).Infof("Post Succeed: %s", string(respContent))
 
 	defer resp.Body.Close()
@@ -137,6 +141,10 @@ func (vmtApi *VmtApi) apiGet(getUrl string) (string, error) {
 		glog.Errorf("Error getting response: %s", err)
 		return "", err
 	}
+	if resp.StatusCode != 200 {
+		glog.Errorf("Response failed: %s", resp.Status)
+		return "", err
+	}
 	glog.V(4).Infof("Get Succeed: %s", string(respContent))
 	defer resp.Body.Close()
 	return respContent, nil
@@ -161,6 +169,10 @@ func (vmtApi *VmtApi) apiDelete(getUrl string) (string, error) {
 	respContent, err := parseAPICallResponse(resp)
 	if err != nil {
 		glog.Errorf("Error getting response: %s", err)
+		return "", err
+	}
+	if resp.StatusCode != 200 {
+		glog.Errorf("Response failed: %s", resp.Status)
 		return "", err
 	}
 	glog.V(4).Infof("DELETE call Succeed: %s", string(respContent))


### PR DESCRIPTION
Bug Description: 
Action supervisor cannot find correct deployment based on the parent object of a Pod. 

Fix:
Instead of find deployment, make the supervisor find replica set that is created by the deployment.

Also changed the vmtapi.go, to make it return err when response status is not "200 OK"